### PR TITLE
Fix surface gaze example to use the new event

### DIFF
--- a/pupil_remote/filter_gaze_on_surface.py
+++ b/pupil_remote/filter_gaze_on_surface.py
@@ -19,15 +19,19 @@ sub_port = req.recv()
 # open a sub port to listen to pupil
 sub = context.socket(zmq.SUB)
 sub.connect("tcp://%s:%s" %(addr,sub_port))
-sub.setsockopt(zmq.SUBSCRIBE, 'gaze')
+sub.setsockopt(zmq.SUBSCRIBE, 'surface')
 surface_name = 'unnamed'
 
 while True:
     topic,msg =  sub.recv_multipart()
-    gaze_position = loads(msg)
+    surface = loads(msg)
     try:
-        gp_x, gp_y = gaze_position["realtime gaze on "+surface_name]
-        if (0<= gp_x <=1 and 0<= gp_y <=1):
-            print "gaze on surface: %s\t - normalized coords: %s, %s" %(surface_name, gp_x, gp_y)
+        if surface["name"] != surface_name:
+            continue
+        coords = surface["gaze_on_srf"]
+        for coord in coords:
+            gp_x, gp_y = coord
+            if (0<= gp_x <=1 and 0<= gp_y <=1):
+                print "gaze on surface: %s\t - normalized coords: %s, %s" %(surface_name, gp_x, gp_y)
     except KeyError:
         pass


### PR DESCRIPTION
I noticed this example was totally wrong when I tried to use it as reference to extract surface gaze events.

I haven't actually tested this Python code, it was done in the Github web editor, regardless of if it actually works it is still better than what  is currently there since it is at least valid reference.

@mkassner 
